### PR TITLE
Fix example code by calling the correct interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ public interface Person {
     Key<Person, LocalDate> dateOfBirth = SimpleKey.named("date of birth");
     Key<Person, FixedRekord<Address>> address = RekordKey.named("address");
 
-    Rekord<Person> rekord = Rekord.of(Person.class)
+    Rekord<Person> rekord = Rekords.of(Person.class)
         .accepting(firstName, lastName, dateOfBirth, address);
 }
 ```


### PR DESCRIPTION
`Record.of` doesn't exist, `Records.of` does. I assume the proposed is the correct usage.
